### PR TITLE
Rewrite browserify config

### DIFF
--- a/config/plugins/browserify.coffee
+++ b/config/plugins/browserify.coffee
@@ -1,20 +1,23 @@
 module.exports = (lineman) ->
+  app = lineman.config.application
+
   config:
-    loadNpmTasks: lineman.config.application.loadNpmTasks.concat("grunt-browserify")
+    loadNpmTasks: app.loadNpmTasks.concat("grunt-browserify")
 
     prependTasks:
-      common: ["browserify"].concat(lineman.config.application.prependTasks.common)
+      common: ["browserify"].concat(app.prependTasks.common)
 
     browserify:
-      app_js:
+      common:
         files:
-          "generated/js/browserifyBundle.js" : "<%= files.js.browserifyBundle %>"
+          "<%= files.browserify.generated %>" : "<%= files.browserify.entrypoint %>"
         options:
-          debug: true
-
-      app_coffee:
-        files:
-          "generated/js/browserifyBundle.coffee.js" : "<%= files.coffee.browserifyBundle %>"
-        options:
-          debug: true
+          debug: false
+          extensions: [".js", ".coffee"]
           transform: ["coffeeify"]
+
+    watch:
+      browserify:
+        files: ["<%= files.js.vendor %>", "<%= files.js.app %>", "<%= files.coffee.app %>"]
+        tasks: ["browserify", "concat_sourcemap:js"]
+

--- a/config/plugins/browserify.coffee
+++ b/config/plugins/browserify.coffee
@@ -10,7 +10,7 @@ module.exports = (lineman) ->
     browserify:
       common:
         files:
-          "<%= files.browserify.generated %>" : "<%= files.browserify.entrypoint %>"
+          "<%= files.browserify.generated %>": "<%= files.browserify.entrypoint %>"
         options:
           debug: false
           extensions: [".js", ".coffee"]
@@ -21,8 +21,29 @@ module.exports = (lineman) ->
             dest: ""
           ]
 
+      spec:
+        files:
+          "<%= files.browserify.generated %>": ["<%= files.js.spec %>", "<%= files.coffee.spec %>"]
+        options:
+          debug: false
+          extensions: [".js", ".coffee"]
+          transform: ["coffeeify"]
+          aliasMappings: [
+              cwd: "vendor/js"
+              src: "**/*.{js,coffee}"
+              dest: ""
+            ,
+              cwd: "app/js"
+              src: "**/*.{js,coffee}"
+              dest: ""
+          ]
+
     watch:
       browserify:
         files: ["<%= files.js.vendor %>", "<%= files.js.app %>", "<%= files.coffee.app %>"]
-        tasks: ["browserify", "concat_sourcemap:js"]
+        tasks: ["browserify:common", "concat_sourcemap:js"]
+
+      browserifySpecs:
+        files: ["<%= files.js.specHelpers %>", "<%= files.js.spec %>", "<%= files.coffee.specHelpers %>", "<%= files.coffee.spec %>"]
+        tasks: ["browserify:spec", "concat_sourcemap:js"]
 

--- a/config/plugins/browserify.coffee
+++ b/config/plugins/browserify.coffee
@@ -23,7 +23,7 @@ module.exports = (lineman) ->
 
       spec:
         files:
-          "<%= files.browserify.generated %>": ["<%= files.js.spec %>", "<%= files.coffee.spec %>"]
+          "<%= files.browserify.generatedSpec %>": ["<%= files.js.spec %>", "<%= files.coffee.spec %>"]
         options:
           debug: false
           extensions: [".js", ".coffee"]

--- a/config/plugins/browserify.coffee
+++ b/config/plugins/browserify.coffee
@@ -15,6 +15,11 @@ module.exports = (lineman) ->
           debug: false
           extensions: [".js", ".coffee"]
           transform: ["coffeeify"]
+          aliasMappings: [
+            cwd: "vendor/js"
+            src: "**/*.{js,coffee}"
+            dest: ""
+          ]
 
     watch:
       browserify:

--- a/config/plugins/coffee.coffee
+++ b/config/plugins/coffee.coffee
@@ -1,0 +1,11 @@
+module.exports = (lineman) ->
+  app = lineman.config.application
+
+  config:
+    removeTasks:
+      common: app.removeTasks.common.concat("coffee")
+
+    watch:
+      coffee:
+        files: []
+        tasks: []

--- a/config/plugins/coffee.coffee
+++ b/config/plugins/coffee.coffee
@@ -9,3 +9,7 @@ module.exports = (lineman) ->
       coffee:
         files: []
         tasks: []
+
+      coffeeSpecs:
+        files: []
+        tasks: []

--- a/config/plugins/concat_sourcemap.coffee
+++ b/config/plugins/concat_sourcemap.coffee
@@ -1,10 +1,17 @@
+_ = require("underscore")
+
 module.exports = (lineman) ->
+  app = lineman.config.application
+
   config:
     concat_sourcemap:
       js:
-        src: [
-          "<%= files.js.vendor %>"
-          "<%= files.js.browserifyBundle %>"
-          "<%= files.coffee.browserifyBundle %>"
-          "<%= files.template.generated %>"
-        ]
+        src: _(app.concat_sourcemap.js.src).without(
+          "<%= files.js.vendor %>", "<%= files.js.app %>", "<%= files.coffee.generated %>"
+        ).concat("<%= files.browserify.generated %>")
+
+
+    watch:
+      js:
+        files: []
+        tasks: []

--- a/config/plugins/concat_sourcemap.coffee
+++ b/config/plugins/concat_sourcemap.coffee
@@ -7,11 +7,24 @@ module.exports = (lineman) ->
     concat_sourcemap:
       js:
         src: _(app.concat_sourcemap.js.src).without(
-          "<%= files.js.vendor %>", "<%= files.js.app %>", "<%= files.coffee.generated %>"
+          "<%= files.js.vendor %>",
+          "<%= files.js.app %>",
+          "<%= files.coffee.generated %>"
         ).concat("<%= files.browserify.generated %>")
 
+      spec:
+        src: _(app.concat_sourcemap.spec.src).without(
+          "<%= files.js.specHelpers %>",
+          "<%= files.coffee.generatedSpecHelpers %>",
+          "<%= files.js.spec %>",
+          "<%= files.coffee.generatedSpec %>"
+        ).concat("<%= files.browserify.generatedSpec %>")
 
     watch:
       js:
+        files: []
+        tasks: []
+
+      jsSpecs:
         files: []
         tasks: []

--- a/config/plugins/files.coffee
+++ b/config/plugins/files.coffee
@@ -1,5 +1,6 @@
 module.exports = (lineman) ->
   files:
     browserify:
-      generated: "generated/js/browserify.js"
       entrypoint: "app/js/entrypoint.{js,coffee}"
+      generated: "generated/js/browserify.js"
+      generatedSpec: "generated/js/browserify-spec.js"

--- a/config/plugins/files.coffee
+++ b/config/plugins/files.coffee
@@ -1,0 +1,5 @@
+module.exports = (lineman) ->
+  files:
+    browserify:
+      generated: "generated/js/browserify.js"
+      entrypoint: "app/js/entrypoint.{js,coffee}"

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -1,0 +1,26 @@
+fs = require('fs')
+path = require('path')
+
+module.exports =
+  initialize: (dir = process.cwd()) ->
+    return unless (topDir = findTopPackageJson(dir)) && (topDir != dir)
+    return if fs.existsSync(dest = path.join(topDir, 'app', 'js', 'entrypoint.coffee'))
+    console.log("Writing a default 'app/js/entrypoint.coffee' file into '#{topDir}'")
+    fs.writeFileSync dest, """
+                           window._ = require("underscore")
+                           require("./hello")
+                           """
+
+findTopPackageJson = (dir) ->
+  current = path.resolve(dir)
+  grandparent = path.resolve(dir, "..", "..")
+  if current == grandparent || !hasPackageJson(grandparent)
+    if hasPackageJson(current)
+      current
+    else
+      null
+  else
+    findTopPackageJson(grandparent)
+
+hasPackageJson = (dir) ->
+  fs.existsSync(path.join(dir, "package.json"))

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -9,6 +9,7 @@ module.exports =
     fs.writeFileSync dest, """
                            window._ = require("underscore")
                            require("./hello")
+
                            """
 
 findTopPackageJson = (dir) ->

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-browserify": "~1.3.0",
     "coffeeify": "~0.5.2",
     "underscore": "~1.6.0",
-    "coffeescript": "~1.6.3"
+    "coffee-script": "~1.6.3"
   },
   "peerDependencies": {
     "coffeeify": "~0.5.2"

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "type": "git",
     "url": "git://github.com/linemanjs/lineman-browserify.git"
   },
-  "peerDependencies": {
+  "dependencies": {
     "lineman": ">= 0.26.0",
-    "coffee-script": "~1.6.3",
     "browserify": "~3.20.0",
     "grunt-browserify": "~1.3.0",
+    "coffeeify": "~0.5.2",
+    "underscore": "~1.6.0"
+  },
+  "peerDependencies": {
     "coffeeify": "~0.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "browserify": "~3.20.0",
     "grunt-browserify": "~1.3.0",
     "coffeeify": "~0.5.2",
-    "underscore": "~1.6.0"
+    "underscore": "~1.6.0",
+    "coffeescript": "~1.6.3"
   },
   "peerDependencies": {
     "coffeeify": "~0.5.2"
@@ -24,6 +25,9 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-release": "~0.7.0"
+  },
+  "scripts": {
+    "postinstall": "node script/postinstall.js"
   },
   "licenses": [
     {

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -1,0 +1,4 @@
+require('coffee-script');
+var initializesAppEntrypoint = require('./../lib/initializes-app-entrypoint');
+
+initializesAppEntrypoint.initialize();


### PR DESCRIPTION
New plan is to attempt to make a single browserify
bundle of JS + Coffee and app + vendor. 

Thoughts:
- We'd remove concat_sourcemap if we could, but other plugins will want
  to use it (conflicts) and we also want our global JST/templates to come
  along.
- concat_sourcemap chokes on the sourcemaps from browserify, which are
  provided as Data URIs. Can it be changed on either side to fix this? #7
- How do we provide multiple basepaths so vendor stuff can be loaded?
