### PR TITLE
respect lineman config `files.browserify.entrypoint`

### DIFF
--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -23,19 +23,19 @@ class EntryPoint
 
   ensureExists: ->
     if @exists(@configuredPattern)
-      console.log "Entry point file '#{@configuredPattern}' already exists; skipping..."
+      console.log "Entry point file '#{@configuredPattern}' already exists; nothing to do..."
 
-    else if @configuredPatternIsDefault()
-      console.log("Writing a default entry point file '#{@default}' into '#{@projectDir}'")
+    else if @isDefaultConfiguration()
+      console.log "Writing a default entry point file '#{@default}' into '#{@projectDir}'"
       grunt.file.write @default, @contents
 
     else
       console.warn "Entry point configured as '#{@configuredPattern}' but no file exists"
 
   exists: (pattern) ->
-    !!grunt.file.expand(pattern).length
+    !! grunt.file.expand(pattern).length
 
-  configuredPatternIsDefault: ->
+  isDefaultConfiguration: ->
     minimatch(@default, @configuredPattern)
 
   contents: """

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -1,5 +1,6 @@
 findsRoot = require('find-root-package')
 grunt = require('lineman').grunt
+minimatch = require('minimatch')
 sh = require('execSync')
 
 module.exports =
@@ -24,9 +25,12 @@ class EntryPoint
     if @exists(@configuredPattern)
       console.log "Entry point file '#{@configuredPattern}' already exists; skipping..."
 
-    else
+    else if minimatch(@default, @configuredPattern)
       console.log("Writing a default entry point file '#{@default}' into '#{@projectDir}'")
       grunt.file.write @default, @contents
+
+    else
+      console.warn "Entry point configured as '#{@configuredPattern}' but no file exists"
 
   exists: (pattern) ->
     !!grunt.file.expand(pattern).length

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -16,10 +16,17 @@ isInstalledAsDependency = (dir, topDir) ->
 
 class EntryPoint
 
-  constructor: (@projectDir, name='entrypoint') ->
+  default: "app/js/entrypoint.coffee"
+
+  contents: """
+            window._ = require("underscore")
+            require("./hello")
+
+            """
+
+  constructor: (@projectDir) ->
     process.chdir @projectDir
     @configuredPattern = sh.exec("lineman config --process files.browserify.entrypoint").stdout.replace(/\s*$/,'')
-    @default = "app/js/#{name}.coffee"
 
   ensureExists: ->
     if @exists(@configuredPattern)
@@ -37,9 +44,3 @@ class EntryPoint
 
   isDefaultConfiguration: ->
     minimatch(@default, @configuredPattern)
-
-  contents: """
-            window._ = require("underscore")
-            require("./hello")
-
-            """

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -1,7 +1,7 @@
 fs = require('fs')
 sh = require('execSync')
-glob = require('glob')
 findsRoot = require('find-root-package')
+grunt = require('lineman').grunt
 
 module.exports =
   initialize: (dir = process.cwd()) ->
@@ -27,7 +27,7 @@ class EntryPoint
       fs.writeFileSync @default, @contents
 
   exists: (pattern) ->
-    !!glob.sync(pattern).length
+    !!grunt.file.expand(pattern).length
 
   contents: """
             window._ = require("underscore")

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -1,7 +1,6 @@
-fs = require('fs')
-sh = require('execSync')
 findsRoot = require('find-root-package')
 grunt = require('lineman').grunt
+sh = require('execSync')
 
 module.exports =
   initialize: (dir = process.cwd()) ->
@@ -24,7 +23,7 @@ class EntryPoint
   ensureExists: ->
     unless @exists(@configuredPattern)
       console.log("Writing a default '#{@default}' file into '#{@projectDir}'")
-      fs.writeFileSync @default, @contents
+      grunt.file.write @default, @contents
 
   exists: (pattern) ->
     !!grunt.file.expand(pattern).length

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -21,8 +21,11 @@ class EntryPoint
     @default = "app/js/#{name}.coffee"
 
   ensureExists: ->
-    unless @exists(@configuredPattern)
-      console.log("Writing a default '#{@default}' file into '#{@projectDir}'")
+    if @exists(@configuredPattern)
+      console.log "Entry point file '#{@configuredPattern}' already exists; skipping..."
+
+    else
+      console.log("Writing a default entry point file '#{@default}' into '#{@projectDir}'")
       grunt.file.write @default, @contents
 
   exists: (pattern) ->

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -18,7 +18,7 @@ class EntryPoint
 
   constructor: (@projectDir, name='entrypoint') ->
     process.chdir @projectDir
-    @configuredPattern = sh.exec("lineman config --process files.browserify.entrypoint").stdout
+    @configuredPattern = sh.exec("lineman config --process files.browserify.entrypoint").stdout.replace(/\s*$/,'')
     @default = "app/js/#{name}.coffee"
 
   ensureExists: ->

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -1,5 +1,4 @@
 fs = require('fs')
-path = require('path')
 sh = require('execSync')
 glob = require('glob')
 findsRoot = require('find-root-package')
@@ -18,16 +17,17 @@ isInstalledAsDependency = (dir, topDir) ->
 class EntryPoint
 
   constructor: (@projectDir, name='entrypoint') ->
-    @pattern = sh.exec("cd #{@projectDir} && lineman config --process files.browserify.entrypoint").stdout
-    @coffee = "app/js/#{name}.coffee"
+    process.chdir @projectDir
+    @configuredPattern = sh.exec("lineman config --process files.browserify.entrypoint").stdout
+    @default = "app/js/#{name}.coffee"
 
   ensureExists: ->
-    unless @exists()
-      console.log("Writing a default '#{@coffee}' file into '#{@projectDir}'")
-      fs.writeFileSync path.join(@projectDir, @coffee), @contents
+    unless @exists(@configuredPattern)
+      console.log("Writing a default '#{@default}' file into '#{@projectDir}'")
+      fs.writeFileSync @default, @contents
 
-  exists: ->
-    !!glob.sync(path.join(@projectDir, @pattern)).length
+  exists: (pattern) ->
+    !!glob.sync(pattern).length
 
   contents: """
             window._ = require("underscore")

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -23,14 +23,14 @@ class EntryPoint
 
   ensureExists: ->
     if @exists(@configuredPattern)
-      console.log "Entry point file '#{@configuredPattern}' already exists; nothing to do..."
+      grunt.log.writeln "Entry point file '#{@configuredPattern}' already exists; nothing to do..."
 
     else if @isDefaultConfiguration()
-      console.log "Writing a default entry point file '#{@default}' into '#{@projectDir}'"
+      grunt.log.ok "Writing a default entry point file '#{@default}' into '#{@projectDir}'"
       grunt.file.write @default, @contents
 
     else
-      console.warn "Entry point configured as '#{@configuredPattern}' but no file exists"
+      grunt.log.error "Entry point configured as '#{@configuredPattern}' but no file exists"
 
   exists: (pattern) ->
     !! grunt.file.expand(pattern).length

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -1,3 +1,4 @@
+chdir = require('chdir')
 findsRoot = require('find-root-package')
 grunt = require('lineman').grunt
 minimatch = require('minimatch')
@@ -8,9 +9,8 @@ module.exports =
     topDir = findsRoot.findTopPackageJson(dir)
     return unless isInstalledAsDependency(dir, topDir)
 
-    process.chdir topDir
-    new EntryPoint(topDir).ensureExists()
-    process.chdir dir
+    chdir topDir, ->
+      new EntryPoint(topDir).ensureExists()
 
 
 isInstalledAsDependency = (dir, topDir) ->

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -7,7 +7,10 @@ module.exports =
   initialize: (dir = process.cwd()) ->
     topDir = findsRoot.findTopPackageJson(dir)
     return unless isInstalledAsDependency(dir, topDir)
+
+    process.chdir topDir
     new EntryPoint(topDir).ensureExists()
+    process.chdir dir
 
 
 isInstalledAsDependency = (dir, topDir) ->
@@ -25,7 +28,6 @@ class EntryPoint
             """
 
   constructor: (@projectDir) ->
-    process.chdir @projectDir
     @configuredPattern = sh.exec("lineman config --process files.browserify.entrypoint").stdout.replace(/\s*$/,'')
 
   ensureExists: ->

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -25,7 +25,7 @@ class EntryPoint
     if @exists(@configuredPattern)
       console.log "Entry point file '#{@configuredPattern}' already exists; skipping..."
 
-    else if minimatch(@default, @configuredPattern)
+    else if @configuredPatternIsDefault()
       console.log("Writing a default entry point file '#{@default}' into '#{@projectDir}'")
       grunt.file.write @default, @contents
 
@@ -34,6 +34,9 @@ class EntryPoint
 
   exists: (pattern) ->
     !!grunt.file.expand(pattern).length
+
+  configuredPatternIsDefault: ->
+    minimatch(@default, @configuredPattern)
 
   contents: """
             window._ = require("underscore")

--- a/lib/initializes-app-entrypoint.coffee
+++ b/lib/initializes-app-entrypoint.coffee
@@ -1,5 +1,7 @@
 fs = require('fs')
 path = require('path')
+sh = require('execSync')
+glob = require('glob')
 findsRoot = require('find-root-package')
 
 module.exports =
@@ -15,9 +17,9 @@ isInstalledAsDependency = (dir, topDir) ->
 
 class EntryPoint
 
-  constructor: (@projectDir, @name='entrypoint') ->
-    @js = "app/js/#{@name}.js"
-    @coffee = "app/js/#{@name}.coffee"
+  constructor: (@projectDir, name='entrypoint') ->
+    @pattern = sh.exec("cd #{@projectDir} && lineman config --process files.browserify.entrypoint").stdout
+    @coffee = "app/js/#{name}.coffee"
 
   ensureExists: ->
     unless @exists()
@@ -25,7 +27,7 @@ class EntryPoint
       fs.writeFileSync path.join(@projectDir, @coffee), @contents
 
   exists: ->
-    fs.existsSync(path.join(@projectDir, @js)) || fs.existsSync(path.join(@projectDir, @coffee))
+    !!glob.sync(path.join(@projectDir, @pattern)).length
 
   contents: """
             window._ = require("underscore")

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "underscore": "~1.6.0",
     "coffee-script": "~1.6.3",
     "find-root-package": "0.0.1",
-    "execSync": "~1.0.1-pre"
+    "execSync": "~1.0.1-pre",
+    "minimatch": "~0.2.14"
   },
   "peerDependencies": {
     "coffeeify": "~0.5.2"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "coffee-script": "~1.6.3",
     "find-root-package": "0.0.1",
     "execSync": "~1.0.1-pre",
-    "minimatch": "~0.2.14"
+    "minimatch": "~0.2.14",
+    "chdir": "0.0.0"
   },
   "peerDependencies": {
     "coffeeify": "~0.5.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "coffeeify": "~0.5.2",
     "underscore": "~1.6.0",
     "coffee-script": "~1.6.3",
-    "find-root-package": "0.0.1"
+    "find-root-package": "0.0.1",
+    "glob": "~3.2.9",
+    "execSync": "~1.0.1-pre"
   },
   "peerDependencies": {
     "coffeeify": "~0.5.2"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "underscore": "~1.6.0",
     "coffee-script": "~1.6.3",
     "find-root-package": "0.0.1",
-    "glob": "~3.2.9",
     "execSync": "~1.0.1-pre"
   },
   "peerDependencies": {


### PR DESCRIPTION
implementation for #12 

items for discussion:
- we are unable to generate a default entrypoint file if the configuration has been customized, but the file doesn't already exist. it was mentioned that we just use `grunt.file.expand`, but that only expands patterns to an array of files that already exist. It does nothing to give is a potential filename that would match the pattern, but doesn't already exist. so instead we just emit a warning/error message
- now emits a console message for the noop state. (entrypoint exists, nothing to do) this at least explains what the postinstall script is doing/was supposed to do
- now uses grunt's api for logging to console in order to get colorized output: (green when creating the default entrypoint file; red when the configuration has been modified but entrypoint file doesn't exist; no color for the noop message)
- we use [substack/node-chdir](https://github.com/substack/node-chdir) to change to the project root directory for the duration of the postinstall script. ensures that cwd is restored at the end. (removes the need for path.joins everywhere)
- currently using [mgutz/execSync](https://github.com/mgutz/execSync) to run the `lineman config` command synchronously. this could be refactored to use node core `child_process` asynchronously
- there is currently no error handling around the `lineman config` system call. this needs added
