### PR TITLE
After rebuilding browserify-spec.js, need to concat_map the specs

### DIFF
--- a/config/plugins/browserify.coffee
+++ b/config/plugins/browserify.coffee
@@ -53,5 +53,5 @@ module.exports = (lineman) ->
 
       browserifySpecs:
         files: ["<%= files.js.specHelpers %>", "<%= files.js.spec %>", "<%= files.coffee.specHelpers %>", "<%= files.coffee.spec %>"]
-        tasks: ["browserify:spec", "concat_sourcemap:js"]
+        tasks: ["browserify:spec", "concat_sourcemap:spec"]
 


### PR DESCRIPTION
As built, the "watch" task doesn't rebuild generated/js/spec.js when the specs change. This appears to be because the plugin is running concat_sourcemap:js rather than concat_sourcemap:spec after it runs browserify:spec.
